### PR TITLE
Adding setup instructions note to individual CDK app READMEs

### DIFF
--- a/nimble_studio_game_development_suite/nimble_studio_build_farm/README.md
+++ b/nimble_studio_game_development_suite/nimble_studio_build_farm/README.md
@@ -4,6 +4,11 @@
 
 This example deploys a complete stack which installs an Incredibuild server as well as supporting infrastructure for use within a Nimble Studio VPC.
 
+### Setup
+
+Follow the instructions in the main repository [README](https://github.com/aws-samples/nimblestudio-game-development-suite/blob/main/README.md) to set up
+this GitHub package and python environment locally.
+
 ### Prerequisites
 
 #### Incredibuild License

--- a/nimble_studio_game_development_suite/nimble_studio_build_pipeline/README.md
+++ b/nimble_studio_game_development_suite/nimble_studio_build_pipeline/README.md
@@ -4,6 +4,11 @@
 
 This example deploys a stack which sets up a [Jenkins](https://www.jenkins.io/) server and build node for use with Nimble Studio.
 
+### Setup
+
+Follow the instructions in the main repository [README](https://github.com/aws-samples/nimblestudio-game-development-suite/blob/main/README.md) to set up
+this GitHub package and python environment locally.
+
 ### Deploy
 
 #### Terminal

--- a/nimble_studio_game_development_suite/nimble_studio_license_server/README.md
+++ b/nimble_studio_game_development_suite/nimble_studio_license_server/README.md
@@ -6,6 +6,11 @@ This example deploys a complete CloudFormation stack which sets up a License Ser
 
 License server setup is based on Nimble Studio's [Create license server documentation](https://docs.aws.amazon.com/nimble-studio/latest/userguide/creating-license-server.html)
 
+### Setup
+
+Follow the instructions in the main repository [README](https://github.com/aws-samples/nimblestudio-game-development-suite/blob/main/README.md) to set up
+this GitHub package and python environment locally.
+
 ### Deploy
 
 #### Terminal

--- a/nimble_studio_game_development_suite/nimble_studio_perforce_server/README.md
+++ b/nimble_studio_game_development_suite/nimble_studio_perforce_server/README.md
@@ -15,6 +15,11 @@ This application performs a download and setup of Perforce Helix Core and Perfor
 You may bring your own Perforce License for use with this application. Refer to the 
 [Perforce documentation on licensing](https://www.perforce.com/resources/vcs/cloud-version-control-guide#licensing).
 
+### Setup
+
+Follow the instructions in the main repository [README](https://github.com/aws-samples/nimblestudio-game-development-suite/blob/main/README.md) to set up
+this GitHub package and python environment locally.
+
 ### Deploy
 
 #### Terminal


### PR DESCRIPTION
*Description of changes:*
* Adding a note to the READMEs of each individual CDK app to clarify that setup instructions should initially be followed from the main repository README. This is in case a user navigates directly to a specific CDK app's README instead of the main README, to ensure that setup is performed properly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
