### PR TITLE
Fixing list typing issue not compatible with older Python versions

### DIFF
--- a/nimble_studio_game_development_suite/nimble_studio_build_pipeline/nimble_studio_build_pipeline_stacks/build_node_image_stack.py
+++ b/nimble_studio_game_development_suite/nimble_studio_build_pipeline/nimble_studio_build_pipeline_stacks/build_node_image_stack.py
@@ -6,6 +6,7 @@ from aws_cdk import (
     aws_s3 as s3,
 )
 from constructs import Construct
+from typing import List
 import sys
 
 sys.path.append("../../utils")
@@ -27,7 +28,7 @@ class BuildNodeImageStack(NestedStack):
         vpce_security_group: ec2.ISecurityGroup or None,
         perforce_security_group: ec2.ISecurityGroup or None,
         artifact_bucket: s3.IBucket,
-        allow_access_from: list[ec2.IPeer],
+        allow_access_from: List[ec2.IPeer],
         ssm_log_bucket: s3.IBucket,
         **kwargs,
     ):

--- a/nimble_studio_game_development_suite/nimble_studio_build_pipeline/nimble_studio_build_pipeline_stacks/jenkins_stack.py
+++ b/nimble_studio_game_development_suite/nimble_studio_build_pipeline/nimble_studio_build_pipeline_stacks/jenkins_stack.py
@@ -5,6 +5,7 @@ from aws_cdk import (
     aws_s3 as s3,
 )
 from constructs import Construct
+from typing import List
 from nimble_studio_build_pipeline.patterns.jenkins_pattern import JenkinsPattern
 
 
@@ -19,7 +20,7 @@ class JenkinsStack(NestedStack):
         key_name: str,
         vpce_security_group: ec2.ISecurityGroup or None,
         perforce_security_group: ec2.ISecurityGroup or None,
-        allow_access_from: list[ec2.IPeer],
+        allow_access_from: List[ec2.IPeer],
         build_node_security_group: ec2.ISecurityGroup,
         ssm_logging_bucket: s3.IBucket,
         **kwargs,

--- a/nimble_studio_game_development_suite/nimble_studio_build_pipeline/patterns/jenkins_pattern.py
+++ b/nimble_studio_game_development_suite/nimble_studio_build_pipeline/patterns/jenkins_pattern.py
@@ -1,5 +1,6 @@
 from aws_cdk import Duration, Tags, Stack, aws_ec2 as ec2, aws_iam as iam, aws_s3 as s3
 from constructs import Construct
+from typing import List
 import sys
 
 sys.path.append("../../utils")
@@ -20,7 +21,7 @@ class JenkinsPattern(Construct):
         subnet: ec2.ISubnet,
         key_name: str,
         security_group: ec2.SecurityGroup,
-        allow_access_from: list[ec2.IPeer],
+        allow_access_from: List[ec2.IPeer],
         build_node_security_group: ec2.ISecurityGroup,
         ssm_logging_bucket: s3.IBucket,
         **kwargs,


### PR DESCRIPTION
*Issue #, if available:*
Using `list` with a generic type is valid in Python 3.9, but not older versions of Python which this app supports. To be backwards compatible, the `List` module from `typing` is needed.

*Description of changes:*
* Updated usage of `list` with a generic type to `List` from `typing`.

Tested with Python 3.7


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
