### PR TITLE
Incredibuild automatic trial license activation

### DIFF
--- a/nimble_studio_game_development_suite/nimble_studio_build_farm/README.md
+++ b/nimble_studio_game_development_suite/nimble_studio_build_farm/README.md
@@ -13,9 +13,9 @@ this GitHub package and python environment locally.
 
 #### Incredibuild License
 
-Place your Incredibuild License file in the `nimble_studio_game_development_suite/nimble_studio_build_farm/incredibuild` folder. 
+If you have an Incredibuild License file, place it in the `nimble_studio_game_development_suite/nimble_studio_build_farm/incredibuild` folder. 
 
-You can download a free trial license from the [Incredibuild website](https://www.incredibuild.com/free-trial).
+Otherwise, the application will download and activate a [free trial license](https://www.incredibuild.com/free-trial) automatically as part of deployment.
 
 ### Deploy
 

--- a/nimble_studio_game_development_suite/nimble_studio_build_farm/nimblestudio/constructs/incredibuild_coordinator.py
+++ b/nimble_studio_game_development_suite/nimble_studio_build_farm/nimblestudio/constructs/incredibuild_coordinator.py
@@ -261,10 +261,15 @@ $machineid = & "C:\\Program Files (x86)\\IncrediBuild\\machineid.exe"
 $data = Get-Content $licensePath
 $bytes = [Convert]::FromBase64String($data)
 [IO.File]::WriteAllBytes($licensePath, $bytes)
-
-& "C:\\Program Files (x86)\\IncrediBuild\\XLicProc.exe" /LICENSEFILE="{IncredibuildCoordinator.INCREDIBUILD_LICENSE_LOCAL_PATH}"
 """
             )
+
+        # Finally, activate the license
+        self._user_data.add_commands(
+            f"""
+& "C:\\Program Files (x86)\\IncrediBuild\\XLicProc.exe" /LICENSEFILE="{IncredibuildCoordinator.INCREDIBUILD_LICENSE_LOCAL_PATH}"
+"""
+        )
 
     def _signal_cloudformation_success_user_data(self):
         # Send the success signal to CloudFormation


### PR DESCRIPTION
*Description of changes:*

Enabling the `nimble_studio_build_farm` application to automatically create an Incredibuild free trial license if there is no license file supplied prior to deployment. 

License is registered as follows:
```
Registered to: Incredibuild Internal Licenses - aws_demo_env
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
