### PR TITLE
Small fixes to incredibuild and perforce stacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,26 +70,26 @@ you can create the virtualenv manually.
 To manually create a virtualenv on MacOS and Linux:
 
 ```
-$ python3 -m venv .venv
+python3 -m venv .venv
 ```
 
 After the init process completes and the virtualenv is created, you can use the following
 step to activate your virtualenv.
 
 ```
-$ source .venv/bin/activate
+source .venv/bin/activate
 ```
 
 If you are a Windows platform, you would activate the virtualenv like this:
 
 ```
-% .venv\Scripts\activate.bat
+.venv\Scripts\activate.bat
 ```
 
 Once the virtualenv is activated, you can install the required dependencies.
 
 ```
-$ pip install -r requirements.txt
+pip install -r requirements.txt
 ```
 
 #### Modular Deployment

--- a/nimble_studio_game_development_suite/nimble_studio_build_farm/README.md
+++ b/nimble_studio_game_development_suite/nimble_studio_build_farm/README.md
@@ -74,16 +74,22 @@ cdk bootstrap aws://<account-number>/<region>
 1. Deploy the project using the following command in the root of the NimbleStudioBuildFarmStack folder 
 
 ```bash
-cdk deploy NimbleStudioBuildFarmStack
+cdk deploy NimbleStudioBuildFarm
 ```
 
 ### Configure
 
 #### Launch Profiles
 
-Deployment of the NimbleStudioBuildFarmStack stack will create an `Incredibuild` studio component resource, which will be available as a studio resource under custom configuration.
+Deployment of the NimbleStudioBuildFarm stack will create an `Incredibuild` studio component resource, which will be available as a studio resource under custom configuration.
 
 This component can be [associated with a Launch Profile](https://docs.aws.amazon.com/nimble-studio/latest/userguide/modifying-launch-profiles.html#modifying-launch-profiles-update) in order to automatically configure the Incredibuild coordinator URL on the Nimble streaming workstation environment.
+
+#### Incredibuild Workers
+
+Deployment of the NimbleStudioBuildFarm stack will create an `IncredibuildWorkerFleet` Auto Scaling Group to spin up worker nodes to help
+with build jobs. Initial deployment will set the desired capacity to zero, but this can be 
+[increased](https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-manual-scaling.html) to launch instances as needed.
 
 ### Development
 

--- a/nimble_studio_game_development_suite/nimble_studio_build_farm/nimblestudio/constructs/incredibuild_coordinator.py
+++ b/nimble_studio_game_development_suite/nimble_studio_build_farm/nimblestudio/constructs/incredibuild_coordinator.py
@@ -119,7 +119,7 @@ class IncredibuildCoordinator(Construct):
             "IncredibuildCoordinator",
             instance_type=InstanceType.of(InstanceClass.BURSTABLE3, InstanceSize.LARGE),
             machine_image=WindowsImage(
-                WindowsVersion.WINDOWS_SERVER_2019_ENGLISH_FULL_BASE
+                WindowsVersion.WINDOWS_SERVER_2022_ENGLISH_FULL_BASE
             ),
             role=coordinator_instance_role,
             # The deploy will fail if the co-ordinator takes over 10 minutes to

--- a/nimble_studio_game_development_suite/nimble_studio_build_farm/nimblestudio/constructs/incredibuild_workers.py
+++ b/nimble_studio_game_development_suite/nimble_studio_build_farm/nimblestudio/constructs/incredibuild_workers.py
@@ -113,7 +113,7 @@ class IncredibuildWorkers(Construct):
                 }
             )
             if worker_ami
-            else WindowsImage(WindowsVersion.WINDOWS_SERVER_2019_ENGLISH_FULL_BASE)
+            else WindowsImage(WindowsVersion.WINDOWS_SERVER_2022_ENGLISH_FULL_BASE)
         )
 
         # Use the instance type specified in the WORKER_INSTANCE_TYPE environment
@@ -187,11 +187,16 @@ class IncredibuildWorkers(Construct):
 
         # Download the Incredibuild silent installer
         incredibuild_installer_local_path = r"C:\temp\IBSetupConsole.exe"
+
         self._user_data.add_commands(
-            f"(New-Object System.Net.WebClient).DownloadFile({incredibuild_installer_location}, {incredibuild_installer_local_path})"
+            f'if (-Not (Test-Path "C:\\temp")) {{ New-Item "C:\\temp" -ItemType Directory }}'
+        )
+
+        self._user_data.add_commands(
+            f'wget -Uri "{incredibuild_installer_location}" -Outfile "{incredibuild_installer_local_path}"'
         )
 
         # Install Incredibuild, and then configure it to connect to the coordinator
         self._user_data.add_commands(
-            f"{incredibuild_installer_local_path} /install /Components=Agent /Coordinator {coordinator_domain_name}"
+            f'{incredibuild_installer_local_path} /install /Components=Agent /Coordinator="{coordinator_domain_name}"'
         )

--- a/nimble_studio_game_development_suite/nimble_studio_perforce_server/nimble_studio_perforce_server_stacks/nimble_studio_perforce_server_main_instance_stack.py
+++ b/nimble_studio_game_development_suite/nimble_studio_perforce_server/nimble_studio_perforce_server_stacks/nimble_studio_perforce_server_main_instance_stack.py
@@ -52,6 +52,7 @@ class NimbleStudioPerforceServerMainInstanceStack(
             self,
             "EFS-Perforce-Depots",
             vpc=self._vpc,
+            security_group=security_group,
             lifecycle_policy=efs.LifecyclePolicy.AFTER_14_DAYS,  # files are not transitioned to infrequent access (IA) storage by default
             performance_mode=efs.PerformanceMode.GENERAL_PURPOSE,  # default
             out_of_infrequent_access_policy=efs.OutOfInfrequentAccessPolicy.AFTER_1_ACCESS,
@@ -83,7 +84,7 @@ class NimbleStudioPerforceServerMainInstanceStack(
             machine_image=linux_image,
             vpc=self._vpc,
             instance_type=ec2.InstanceType.of(
-                ec2.InstanceClass.M5,
+                ec2.InstanceClass.MEMORY5,
                 ec2.InstanceSize.LARGE,
             ),
             key_name=self._key_pair_name,


### PR DESCRIPTION
*Description of changes:*

This PR includes a few small changes/fixes:

1. README updates to setup commands 
1. README updates for Incredibuild stack
1. Incredibuild machine_image updates from WindowsServer2019 -> 2022
1. Incredibuild agent silent installer command updates
1. Perforce instance type fix and hxdepots mounted EFS security group update to use the Perforce created security group

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
